### PR TITLE
Finer Grained Validation Results

### DIFF
--- a/src/PrusaSlicer.cpp
+++ b/src/PrusaSlicer.cpp
@@ -414,9 +414,12 @@ int CLI::run(int argc, char **argv)
                         fff_print.auto_assign_extruders(mo);
                 }
                 print->apply(model, m_print_config);
-                std::string err = print->validate();
-                if (! err.empty()) {
-                    boost::nowide::cerr << err << std::endl;
+                const auto validation_result{print->validate()};
+                if (!validation_result.warnings.empty()) {
+                    boost::nowide::cerr << validation_result.get_warnings_concatenated() << std::endl;
+                }
+                if (!validation_result.errors.empty()) {
+                    boost::nowide::cerr << validation_result.get_errors_concatenated() << std::endl;
                     return 1;
                 }
                 if (print->empty())

--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -200,6 +200,8 @@ add_library(libslic3r STATIC
     SLA/SLARasterWriter.cpp
     SLA/ConcaveHull.hpp
     SLA/ConcaveHull.cpp
+    ValidationResult.hpp
+    ValidationResult.cpp
 )
 
 encoding_check(libslic3r)

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1171,7 +1171,7 @@ ValidationResult Print::validate() const
     // Helper lambda to populate the ValidationResult with the provided error and return a reference to it. See how it is used below.
     // This may allow one or more warnings to be set first before a show-stopping error is added and returned.
     auto validation_error = [&result](auto&& error_string) -> ValidationResult& {
-        result.errors.emplace_back(error_string);
+        result.errors.emplace(error_string);
         return result;
     };
 
@@ -1417,28 +1417,28 @@ ValidationResult Print::validate() const
                 first_layer_min_nozzle_diameter = min_nozzle_diameter;
             }
             if (first_layer_height > first_layer_min_nozzle_diameter)
-                result.warnings.emplace_back(L("First layer height can't be greater than nozzle diameter"));
+                result.warnings.emplace(L("First layer height can't be greater than nozzle diameter"));
             
             // validate layer_height (produces warning)
             double layer_height = object->config().layer_height.value;
             if (layer_height > min_nozzle_diameter)
-                result.warnings.emplace_back(L("Layer height can't be greater than nozzle diameter"));
+                result.warnings.emplace(L("Layer height can't be greater than nozzle diameter"));
 
             // Validate extrusion widths (produces warnings)
             std::string warn_msg;
             if (!validate_extrusion_width(object->config(), "extrusion_width", layer_height, warn_msg))
             {
-                result.warnings.push_back(std::move(warn_msg));
+                result.warnings.insert(std::move(warn_msg));
             }
             if ((object->config().support_material || object->config().raft_layers > 0) && ! validate_extrusion_width(object->config(), "support_material_extrusion_width", layer_height, warn_msg))
             {
-                result.warnings.push_back(std::move(warn_msg));
+                result.warnings.insert(std::move(warn_msg));
             }
             for (const char *opt_key : { "perimeter_extrusion_width", "external_perimeter_extrusion_width", "infill_extrusion_width", "solid_infill_extrusion_width", "top_infill_extrusion_width" })
 				for (size_t i = 0; i < object->region_volumes.size(); ++ i)
             		if (! object->region_volumes[i].empty() && ! validate_extrusion_width(this->get_region(i)->config(), opt_key, layer_height, warn_msg))
                     {
-                        result.warnings.push_back(std::move(warn_msg));
+                        result.warnings.insert(std::move(warn_msg));
                     }
         }
     }

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -14,6 +14,7 @@
 #if ENABLE_THUMBNAIL_GENERATOR
 #include "GCode/ThumbnailData.hpp"
 #endif // ENABLE_THUMBNAIL_GENERATOR
+#include "ValidationResult.hpp"
 
 namespace Slic3r {
 
@@ -327,7 +328,7 @@ public:
     bool                has_skirt() const;
 
     // Returns an empty string if valid, otherwise returns an error message.
-    std::string         validate() const override;
+    ValidationResult    validate() const override;
     BoundingBox         bounding_box() const;
     BoundingBox         total_bounding_box() const;
     double              skirt_first_layer_height() const;

--- a/src/libslic3r/PrintBase.hpp
+++ b/src/libslic3r/PrintBase.hpp
@@ -16,6 +16,7 @@
 #include "Model.hpp"
 #include "PlaceholderParser.hpp"
 #include "PrintConfig.hpp"
+#include "ValidationResult.hpp"
 
 namespace Slic3r {
 
@@ -228,8 +229,8 @@ public:
     // or after apply() over a model, where no object is printable (all outside the print volume).
     virtual bool            empty() const = 0;
 
-    // Validate the print, return empty string if valid, return error if process() cannot (or should not) be started.
-    virtual std::string     validate() const { return std::string(); }
+    // Validate the print. Result determines if process() cannot (or should not) be started.
+    virtual ValidationResult     validate() const { return {}; }
 
     enum ApplyStatus {
         // No change after the Print::apply() call.

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3016,7 +3016,7 @@ void DynamicPrintConfig::set_num_extruders(unsigned int num_extruders)
     }
 }
 
-std::string DynamicPrintConfig::validate()
+std::string DynamicPrintConfig::validate() // TODO: consider switching return type to ValidationResult
 {
     // Full print config is initialized from the defaults.
     const ConfigOption *opt = this->option("printer_technology", false);
@@ -3052,7 +3052,7 @@ double PrintConfig::min_object_distance(const ConfigBase *config)
 }
 
 //FIXME localize this function.
-std::string FullPrintConfig::validate()
+std::string FullPrintConfig::validate() // TODO: consider switching return type to ValidationResult
 {
     // --layer-height
     if (this->get_abs_value("layer_height") <= 0)

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -248,6 +248,7 @@ public:
     void 				set_num_extruders(unsigned int num_extruders);
 
     // Validate the PrintConfig. Returns an empty string on success, otherwise an error message is returned.
+    // TODO: consider switching return type to ValidationResult
     std::string         validate();
 
     // Verify whether the opt_key has not been obsoleted or renamed.
@@ -949,6 +950,7 @@ class FullPrintConfig :
 
 public:
     // Validate the FullPrintConfig. Returns an empty string on success, otherwise an error message is returned.
+    // TODO: consider switching return type to ValidationResult
     std::string                 validate();
 
 protected:
@@ -1212,7 +1214,8 @@ class SLAFullPrintConfig : public SLAPrinterConfig, public SLAPrintConfig, publi
 
 public:
     // Validate the SLAFullPrintConfig. Returns an empty string on success, otherwise an error message is returned.
-//    std::string                 validate();
+    // TODO: consider switching return type to ValidationResult
+    // std::string                 validate();
 
 protected:
     // Protected constructor to be called to initialize ConfigCache::m_default.

--- a/src/libslic3r/SLA/SLAPad.cpp
+++ b/src/libslic3r/SLA/SLAPad.cpp
@@ -8,6 +8,7 @@
 #include "ClipperUtils.hpp"
 #include "Tesselate.hpp"
 #include "MTUtils.hpp"
+#include "ValidationResult.hpp"
 
 // For debugging:
 // #include <fstream>
@@ -680,16 +681,18 @@ void create_pad(const ExPolygons &sup_blueprint,
     out.merge(mesh(std::move(t)));
 }
 
-std::string PadConfig::validate() const
+ValidationResult PadConfig::validate() const
 {
+    ValidationResult result;
+
     static const double constexpr MIN_BRIM_SIZE_MM = .1;
 
     if (brim_size_mm < MIN_BRIM_SIZE_MM ||
         bottom_offset() > brim_size_mm + wing_distance() ||
         get_waffle_offset(*this) <= MIN_BRIM_SIZE_MM)
-        return L("Pad brim size is too small for the current configuration.");
+        result.errors.emplace_back(L("Pad brim size is too small for the current configuration."));
 
-    return "";
+    return result;
 }
 
 }} // namespace Slic3r::sla

--- a/src/libslic3r/SLA/SLAPad.cpp
+++ b/src/libslic3r/SLA/SLAPad.cpp
@@ -690,7 +690,7 @@ ValidationResult PadConfig::validate() const
     if (brim_size_mm < MIN_BRIM_SIZE_MM ||
         bottom_offset() > brim_size_mm + wing_distance() ||
         get_waffle_offset(*this) <= MIN_BRIM_SIZE_MM)
-        result.errors.emplace_back(L("Pad brim size is too small for the current configuration."));
+        result.errors.emplace(L("Pad brim size is too small for the current configuration."));
 
     return result;
 }

--- a/src/libslic3r/SLA/SLAPad.hpp
+++ b/src/libslic3r/SLA/SLAPad.hpp
@@ -6,6 +6,8 @@
 #include <cmath>
 #include <string>
 
+#include "ValidationResult.hpp"
+
 namespace Slic3r {
 
 class ExPolygon;
@@ -79,7 +81,7 @@ struct PadConfig {
     /// Returns the elevation needed for compensating the pad.
     inline double required_elevation() const { return wall_thickness_mm; }
 
-    std::string validate() const;
+    ValidationResult validate() const;
 };
 
 void create_pad(const ExPolygons &support_contours,

--- a/src/libslic3r/SLAPrint.cpp
+++ b/src/libslic3r/SLAPrint.cpp
@@ -670,7 +670,7 @@ ValidationResult SLAPrint::validate() const
         if(supports_en &&
            mo->sla_points_status == sla::PointsStatus::UserModified &&
            mo->sla_support_points.empty()) {
-            result.errors.emplace_back(L("Cannot proceed without support points! "
+            result.errors.emplace(L("Cannot proceed without support points! "
                      "Add support points or disable support generation."));
             return result;
         }
@@ -683,7 +683,7 @@ ValidationResult SLAPrint::validate() const
         sla::PadConfig::EmbedObject &builtinpad = padcfg.embed_object;
         
         if(supports_en && !builtinpad.enabled && elv < cfg.head_fullwidth()) {
-            result.errors.emplace_back(L(
+            result.errors.emplace(L(
                 "Elevation is too low for object. Use the \"Pad around "
                 "object\" feature to print the object without elevation."));
             return result;
@@ -691,7 +691,7 @@ ValidationResult SLAPrint::validate() const
         
         if(supports_en && builtinpad.enabled &&
            cfg.pillar_base_safety_distance_mm < builtinpad.object_gap_mm) {
-            result.errors.emplace_back(L(
+            result.errors.emplace(L(
                 "The endings of the support pillars will be deployed on the "
                 "gap between the object and the pad. 'Support base safety "
                 "distance' has to be greater than the 'Pad object gap' "
@@ -712,7 +712,7 @@ ValidationResult SLAPrint::validate() const
     double expt_cur = m_material_config.exposure_time.getFloat();
 
     if (expt_cur < expt_min || expt_cur > expt_max) {
-        result.errors.emplace_back(L("Exposition time is out of printer profile bounds."));
+        result.errors.emplace(L("Exposition time is out of printer profile bounds."));
         return result;
     }
 
@@ -721,7 +721,7 @@ ValidationResult SLAPrint::validate() const
     double iexpt_cur = m_material_config.initial_exposure_time.getFloat();
 
     if (iexpt_cur < iexpt_min || iexpt_cur > iexpt_max) {
-        result.errors.emplace_back(L("Initial exposition time is out of printer profile bounds."));
+        result.errors.emplace(L("Initial exposition time is out of printer profile bounds."));
         return result;
     }
 

--- a/src/libslic3r/SLAPrint.hpp
+++ b/src/libslic3r/SLAPrint.hpp
@@ -8,6 +8,7 @@
 #include "Point.hpp"
 #include "MTUtils.hpp"
 #include "Zipper.hpp"
+#include "ValidationResult.hpp"
 #include <libnest2d/backends/clipper/clipper_polygon.hpp>
 
 namespace Slic3r {
@@ -385,7 +386,7 @@ public:
 
     const SLAPrintStatistics&   print_statistics() const { return m_print_statistics; }
 
-    std::string validate() const override;
+    ValidationResult validate() const override;
 
     // An aggregation of SliceRecord-s from all the print objects for each
     // occupied layer. Slice record levels dont have to match exactly.

--- a/src/libslic3r/ValidationResult.cpp
+++ b/src/libslic3r/ValidationResult.cpp
@@ -1,6 +1,6 @@
 #include "ValidationResult.hpp"
 
-#include <vector>
+#include <unordered_set>
 #include <string>
 #include <sstream>
 #include <ostream>
@@ -15,11 +15,11 @@ namespace
 // Helper method to concatenate all strings in a vector.
 // Newline included between each.
 // Each run through internationalization to be translated.
-std::string concatenate(const std::vector<std::string>& vector_of_strings,
+std::string concatenate(const std::unordered_set<std::string>& strings,
     const ValidationResult::TranslateStdStringFn& translate)
 {
     std::ostringstream oss;
-    for (auto it = vector_of_strings.cbegin(); it != vector_of_strings.cend(); )
+    for (auto it = strings.cbegin(); it != strings.cend(); )
     {
         // Translate and add to the output stream
         if (translate)
@@ -31,7 +31,7 @@ std::string concatenate(const std::vector<std::string>& vector_of_strings,
             oss << *it;
         }
         // Put a newline between each but not at the end of the list
-        if (++it != vector_of_strings.cend())
+        if (++it != strings.cend())
         {
             oss << std::endl;
         }
@@ -56,7 +56,9 @@ std::string ValidationResult::get_errors_and_warnings_concatenated(const Validat
 {
     std::ostringstream oss;
     oss << concatenate(errors, translate);
-    oss << std::endl;
+    // Only insert newlines separating errors and warnings if there were both errors and warnings
+    if (!errors.empty() && !warnings.empty())
+        oss << std::endl << std::endl;
     oss << concatenate(warnings, translate);
     return oss.str();
 }
@@ -74,8 +76,10 @@ void ValidationResult::clear()
 
 void ValidationResult::append(ValidationResult&& other)
 {
-    errors.insert(errors.cend(), std::make_move_iterator(other.errors.begin()), std::make_move_iterator(other.errors.end()));
-    warnings.insert(warnings.cend(), std::make_move_iterator(other.warnings.begin()), std::make_move_iterator(other.warnings.end()));
+    errors.insert(std::make_move_iterator(other.errors.begin()),
+                  std::make_move_iterator(other.errors.end()));
+    warnings.insert(std::make_move_iterator(other.warnings.begin()),
+                    std::make_move_iterator(other.warnings.end())); 
 }
 
 }  // namespace Slic3r

--- a/src/libslic3r/ValidationResult.cpp
+++ b/src/libslic3r/ValidationResult.cpp
@@ -1,0 +1,81 @@
+#include "ValidationResult.hpp"
+
+#include <vector>
+#include <string>
+#include <sstream>
+#include <ostream>
+#include <functional>
+#include <iterator>
+
+namespace Slic3r {
+
+namespace
+{
+
+// Helper method to concatenate all strings in a vector.
+// Newline included between each.
+// Each run through internationalization to be translated.
+std::string concatenate(const std::vector<std::string>& vector_of_strings,
+    const ValidationResult::TranslateStdStringFn& translate)
+{
+    std::ostringstream oss;
+    for (auto it = vector_of_strings.cbegin(); it != vector_of_strings.cend(); )
+    {
+        // Translate and add to the output stream
+        if (translate)
+        {
+            oss << translate(*it);
+        }
+        else
+        {
+            oss << *it;
+        }
+        // Put a newline between each but not at the end of the list
+        if (++it != vector_of_strings.cend())
+        {
+            oss << std::endl;
+        }
+    }
+    return oss.str();
+}
+
+}  // namespace
+
+
+std::string ValidationResult::get_errors_concatenated(const ValidationResult::TranslateStdStringFn& translate) const
+{
+    return concatenate(errors, translate);
+}
+
+std::string ValidationResult::get_warnings_concatenated(const ValidationResult::TranslateStdStringFn& translate) const
+{
+    return concatenate(errors, translate);
+}
+
+std::string ValidationResult::get_errors_and_warnings_concatenated(const ValidationResult::TranslateStdStringFn& translate) const
+{
+    std::ostringstream oss;
+    oss << concatenate(errors, translate);
+    oss << std::endl;
+    oss << concatenate(warnings, translate);
+    return oss.str();
+}
+
+bool ValidationResult::empty() const
+{
+    return errors.empty() && warnings.empty();
+}
+
+void ValidationResult::clear()
+{
+    errors.clear();
+    warnings.clear();
+}
+
+void ValidationResult::append(ValidationResult&& other)
+{
+    errors.insert(errors.cend(), std::make_move_iterator(other.errors.begin()), std::make_move_iterator(other.errors.end()));
+    warnings.insert(warnings.cend(), std::make_move_iterator(other.warnings.begin()), std::make_move_iterator(other.warnings.end()));
+}
+
+}  // namespace Slic3r

--- a/src/libslic3r/ValidationResult.hpp
+++ b/src/libslic3r/ValidationResult.hpp
@@ -1,0 +1,50 @@
+#ifndef slic3r_ValidationResult_hpp_
+#define slic3r_ValidationResult_hpp_
+
+#include <vector>
+#include <string>
+#include <functional>
+
+namespace Slic3r {
+
+// Encapsulates errors and warnings that can result from validating configurations.
+struct ValidationResult
+{
+    // Translation function type taking an std::string as input and producing an std::string as output.
+    using TranslateStdStringFn = std::function<std::string(const std::string&)>;
+
+    // Returns all errors concatenated as one string. Newlines separate each.
+    // If a translation function is provided, each message gets translated individually.
+    std::string get_errors_concatenated(const TranslateStdStringFn& translate = {}) const;
+
+    // Returns all warnings concatenated as one string. Newlines separate each.
+    // If a translation function is provided, each message gets translated individually.
+    std::string get_warnings_concatenated(const TranslateStdStringFn& translate = {}) const;
+
+    // Returns all errors and warnings concatenated as one string.
+    // Errors come first, then warnings. All separated by newline delimiters.
+    // If a translation function is provided, each message gets translated individually.
+    std::string get_errors_and_warnings_concatenated(const TranslateStdStringFn& translate = {}) const;
+
+    // Returns whether there are any errors or there are any warnings.
+    // True if there are both no errors and no warnings, false if there is any warning or error.
+    bool empty() const;
+
+    // Clears out both the errors and warnings.
+    void clear();
+
+    // Appends the contents of another ValidationResult to this one.
+    void append(ValidationResult&& other);
+
+    // Error message strings.
+    // It is expected that these will be pre-translation strings which can be run through I18N later.
+    std::vector<std::string> errors;
+
+    // Warning message strings.
+    // It is expected that these will be pre-translation strings which can be run through I18N later.
+    std::vector<std::string> warnings;
+};
+
+}
+
+#endif /* slic3r_ValidationResult_hpp_ */

--- a/src/libslic3r/ValidationResult.hpp
+++ b/src/libslic3r/ValidationResult.hpp
@@ -1,7 +1,7 @@
 #ifndef slic3r_ValidationResult_hpp_
 #define slic3r_ValidationResult_hpp_
 
-#include <vector>
+#include <unordered_set>
 #include <string>
 #include <functional>
 
@@ -38,11 +38,11 @@ struct ValidationResult
 
     // Error message strings.
     // It is expected that these will be pre-translation strings which can be run through I18N later.
-    std::vector<std::string> errors;
+    std::unordered_set<std::string> errors;
 
     // Warning message strings.
     // It is expected that these will be pre-translation strings which can be run through I18N later.
-    std::vector<std::string> warnings;
+    std::unordered_set<std::string> warnings;
 };
 
 }

--- a/src/slic3r/GUI/BackgroundSlicingProcess.cpp
+++ b/src/slic3r/GUI/BackgroundSlicingProcess.cpp
@@ -21,6 +21,7 @@
 #include "libslic3r/GCode/PostProcessor.hpp"
 #include "libslic3r/GCode/PreviewData.hpp"
 #include "libslic3r/libslic3r.h"
+#include "libslic3r/ValidationResult.hpp"
 
 #include <cassert>
 #include <stdexcept>
@@ -355,7 +356,7 @@ bool BackgroundSlicingProcess::empty() const
 	return m_print->empty();
 }
 
-std::string BackgroundSlicingProcess::validate()
+ValidationResult BackgroundSlicingProcess::validate()
 {
 	assert(m_print != nullptr);
 	return m_print->validate();

--- a/src/slic3r/GUI/BackgroundSlicingProcess.hpp
+++ b/src/slic3r/GUI/BackgroundSlicingProcess.hpp
@@ -12,6 +12,7 @@
 #include "libslic3r/Print.hpp"
 #include "slic3r/Utils/PrintHost.hpp"
 #include "slic3r/Utils/Thread.hpp"
+#include "libslic3r/ValidationResult.hpp"
 
 namespace Slic3r {
 
@@ -92,9 +93,9 @@ public:
 	void 		set_task(const PrintBase::TaskParams &params);
 	// After calling apply, the empty() call will report whether there is anything to slice.
 	bool 		empty() const;
-	// Validate the print. Returns an empty string if valid, returns an error message if invalid.
-	// Call validate before calling start().
-	std::string validate();
+	// Validate the print.
+	// Call validate and examine its results before calling start().
+	ValidationResult validate();
 
 	// Set the export path of the G-code.
 	// Once the path is set, the G-code 

--- a/src/slic3r/GUI/GUI.cpp
+++ b/src/slic3r/GUI/GUI.cpp
@@ -241,7 +241,7 @@ void show_info(wxWindow* parent, const wxString& message, const wxString& title)
 	msg_wingow.ShowModal();
 }
 
-void warning_catcher(wxWindow* parent, const wxString& message)
+void show_warning(wxWindow* parent, const wxString& message)
 {
 	wxMessageDialog msg(parent, message, _(L("Warning")), wxOK | wxICON_WARNING);
 	msg.ShowModal();

--- a/src/slic3r/GUI/GUI.hpp
+++ b/src/slic3r/GUI/GUI.hpp
@@ -41,7 +41,7 @@ void change_opt_value(DynamicPrintConfig& config, const t_config_option_key& opt
 void show_error(wxWindow* parent, const wxString& message);
 void show_error_id(int id, const std::string& message);   // For Perl
 void show_info(wxWindow* parent, const wxString& message, const wxString& title);
-void warning_catcher(wxWindow* parent, const wxString& message);
+void show_warning(wxWindow* parent, const wxString& message);
 
 // Creates a wxCheckListBoxComboPopup inside the given wxComboCtrl, filled with the given text and items.
 // Items are all initialized to the given value.

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -1220,7 +1220,7 @@ bool GUI_App::config_wizard_startup()
 }
 
 // static method accepting a wxWindow object as first parameter
-// void warning_catcher{
+// void show_warning{
 //     my($self, $message_dialog) = @_;
 //     return sub{
 //         my $message = shift;

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -840,7 +840,7 @@ void MainFrame::quick_slice(const int qs)
 //             sprint->export_gcode();
 //         }
 //         sprint->status_cb(undef);
-//         Slic3r::GUI::warning_catcher($self)->($_) for @warnings;
+//         Slic3r::GUI::show_warning($self)->($_) for @warnings;
     }
     m_progress_dialog->Destroy();
     m_progress_dialog = nullptr;

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -141,7 +141,7 @@ void PreferencesDialog::build()
 void PreferencesDialog::accept()
 {
     if (m_values.find("no_defaults") != m_values.end()) {
-        warning_catcher(this, wxString::Format(_(L("You need to restart %s to make the changes effective.")), SLIC3R_APP_NAME));
+        show_warning(this, wxString::Format(_(L("You need to restart %s to make the changes effective.")), SLIC3R_APP_NAME));
 	}
 
 	auto app_config = get_app_config();


### PR DESCRIPTION
These changes separate validation errors (show-stopping) from validation warnings (slicing may continue, but print results may not be great).

The motivation for this was this issue: https://github.com/prusa3d/PrusaSlicer/issues/3079
The problem is that some validation checks are not really hard failure modes, but warnings for the user to consider.

With this PR, there can be both warnings and errors reported by validate(), whereas before only one error could be reported at a time.

To do:
- [ ] update tests
- [ ] investigate issue where warning message can appear multiple times when changing printer machine limits settings
- [x] omit duplicate errors/warnings (can happen when the same validation check fails for each print on the platter)